### PR TITLE
Upgrade to javadoc 3.1.1 which understands '8' instead of '1.8' for t…

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -37,7 +37,7 @@
         <maven.failsafe.version>2.22.2</maven.failsafe.version>
         <maven.gmavenplus.version>1.6.1</maven.gmavenplus.version>
         <maven.jacoco.version>0.8.2</maven.jacoco.version>
-        <maven.javadoc.version>3.0.1</maven.javadoc.version>
+        <maven.javadoc.version>3.1.1</maven.javadoc.version>
         <maven.plugin.version>3.6.0</maven.plugin.version>
         <maven.shade.version>3.1.1</maven.shade.version>
         <maven.source.version>3.0.1</maven.source.version>


### PR DESCRIPTION
…he java version

This fixes the links to the jdk objects in the generated javadoc. For example,
before this fix you get "java.lang.String", after this fix you get a clickable "String"

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)




**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix



**What is the current behavior?** *(You can also link to an open issue here)*
The javadocs for jdk objects are like "java.lang.String"


**What is the new behavior (if this is a feature change)?**
The javadocs for jkd objects are like "String" (clickable link to oracle.com/docs/..)



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
