### PR TITLE
use our powsybl base image by default

### DIFF
--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -28,9 +28,7 @@
         <maven.spring-boot.version>2.2.9.RELEASE</maven.spring-boot.version>
         <maven.git-commit-id.version>4.0.3</maven.git-commit-id.version>
 
-        <jib.from.image.type>openjdk</jib.from.image.type> <!-- openjdk, distroless, etc. -->
-        <jib.from.image.classifier></jib.from.image.classifier> <!-- for openjdk, empty, -alpine, etc. -->
-        <jib.from.image>${jib.from.image.type}:${java.version}${jib.from.image.classifier}</jib.from.image>
+        <jib.from.image>powsybl/java:1.0.0</jib.from.image>
 
         <!-- copied from spring-boot-starter-parent -->
         <maven.resource.delimiter>@</maven.resource.delimiter>


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
uses openjdk:11, root


**What is the new behavior (if this is a feature change)?**
uses powsybl/java, powsybl user


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
sets the workdir to /home/powsybl, and the user to powsybl, so not root. This may require users to modify their docker config to adapt to less permissions, and a different workdir

**Other information**:
