### PR TITLE
Add jib spring profiles and /config default configuration

### DIFF
--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -30,6 +30,17 @@
 
         <jib.from.image>powsybl/java:1.0.0</jib.from.image>
 
+        <!--
+        SPRING_PROFILES_ACTIVE: remove extra profiles. This is used for example to remove the "local" profile
+        which allows running apps in an IDE and have it connect to localhost for its dependencies
+
+        SPRING_CONFIG_LOCATION: change the working dir from spring config location to /config. The working dir
+        is RW in /home, while the config is RO in /config. Keep the other spring default locations.
+
+        NOTE: using a single line without whitespace to avoid messing up the environment
+        -->
+        <jib.container.environment>SPRING_PROFILES_ACTIVE=default,SPRING_CONFIG_LOCATION=optional:classpath:/;optional:classpath:/config/;optional:file:/config/;optional:file:/config/*/</jib.container.environment>
+
         <!-- copied from spring-boot-starter-parent -->
         <maven.resource.delimiter>@</maven.resource.delimiter>
         <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Powsybl ws projects docker images duplicate the removal of the "local" spring profile
powsybl ws projects docker images don't read subdirs of /config (like /config/config)


**What is the new behavior (if this is a feature change)?**
shared "local" profile remove, shared configuration to read from /config and all children


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
