### PR TITLE
Use reproducible builds by default

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -66,6 +66,9 @@
         <sonar.exclusions>
             **/generated/**/*
         </sonar.exclusions>
+
+        <!-- reproducible builds -->
+        <project.build.outputTimestamp>1970-01-01T00:00:00Z</project.build.outputTimestamp>
     </properties>
 
     <build>


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bugfix


**What is the current behavior?** *(You can also link to an open issue here)*
by default builds are not byte for byte reproducible (jar, docker images, itools packager zip)


**What is the new behavior (if this is a feature change)?**
by default builds are byte for byte reproducible (jar, docker images, itools packager zip)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO


**Other information**:
needs a fix for itools packager, and a change in the code that puts the real current time in a java-template in powsybl-core/tool or other projecst ( @AutoService(Version.class) system)