### PR TITLE
powsybl-parent-ws: generated liquibase changeset file name with '_' instead of ':' in the date

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then, you can do one of the following:
 ##### Creating changesets
 The most common operation is to generate a new changeSet corresponding to the differences between the existing changesets, and the jpa annotation in the source code. Use this command when you have created or modified your jpa annotations.
   ```
-  mvn clean compile liquibase:update liquibase:diff
+  mvn clean compile liquibase:update liquibase:diff -Dpowsybl.liquibase.generate
   ```
 Note1: for the very first changeset in a projet, omit the "liquibase:update" part of the command line
 

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -382,5 +382,17 @@ jib.to.image = finalName;
                 </pluginManagement>
             </build>
         </profile>
+        <profile>
+            <id>powsyblliquibase</id>
+            <activation>
+                <property>
+                    <name>powsybl.liquibase.generate</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.build.timestamp.format>yyyyMMdd'T'HHmmssX</maven.build.timestamp.format>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature, avoid ':' in filename: omit all separators for simplicity. It causes problems on windows, it's escaped by default in bash (COMP_WORDBREAK), it's weird..


**What is the current behavior?** *(You can also link to an open issue here)*
generated changeset name 
changelog_2022-10-06T14:54:31Z.xml


**What is the new behavior (if this is a feature change)?**
generated changeset name 
changelog_20221006T145431Z.xml


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO