### PR TITLE
Upgrade Jacoco maven plugin to be compatible with Java 19

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -44,7 +44,7 @@
             so projects can detect errors early and fix their groovydoc configuration.
         -->
         <maven.groovydoc.version>${groovy.version}</maven.groovydoc.version>
-        <maven.jacoco.version>0.8.6</maven.jacoco.version>
+        <maven.jacoco.version>0.8.8</maven.jacoco.version>
         <maven.javadoc.version>3.2.0</maven.javadoc.version>
         <maven.plugin.version>3.6.0</maven.plugin.version>
         <maven.shade.version>3.2.4</maven.shade.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
We use Jacoco plugin 0.8.6.


**What is the new behavior (if this is a feature change)?**
We use Jacoco plugin 0.8.8 compatible with JDK 19.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
