### PR TITLE
Upgrade to java17

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -28,8 +28,7 @@
     </modules>
 
     <properties>
-        <!-- javac's source and target arguments accept both 1.8 and 8, but release accepts only 8 -->
-        <java.version>8</java.version>
+        <java.version>17</java.version>
 
         <maven.buildnumber.version>1.4</maven.buildnumber.version>
         <maven.checkstyle.version>3.1.1</maven.checkstyle.version>
@@ -46,7 +45,7 @@
         <maven.groovydoc.version>${groovy.version}</maven.groovydoc.version>
         <maven.jacoco.version>0.8.8</maven.jacoco.version>
         <maven.javadoc.version>3.2.0</maven.javadoc.version>
-        <maven.plugin.version>3.6.0</maven.plugin.version>
+        <maven.plugin.version>3.6.1</maven.plugin.version>
         <maven.shade.version>3.2.4</maven.shade.version>
         <maven.source.version>3.2.1</maven.source.version>
         <maven.templating.version>1.0.0</maven.templating.version>

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -24,11 +24,11 @@
     <description>Powsybl Parent for Web Services</description>
 
     <properties>
-        <maven.jib.version>2.7.0</maven.jib.version>
+        <maven.jib.version>2.8.0</maven.jib.version>
         <maven.spring-boot.version>2.6.6</maven.spring-boot.version>
         <maven.git-commit-id.version>4.0.3</maven.git-commit-id.version>
 
-        <jib.from.image>powsybl/java:1.0.0</jib.from.image>
+        <jib.from.image>powsybl/java:2.0.0</jib.from.image>
 
         <!--
         SPRING_PROFILES_ACTIVE: remove extra profiles. This is used for example to remove the "local" profile


### PR DESCRIPTION
bump jib to 2.8 because jib 2.7 can't autodetect the mainclass when compiled with java17 : Unsupported class file major version 61 See https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#i-am-seeing-unsupported-class-file-major-version-when-building

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
