### PR TITLE
bump maven.git-commit-id.version 4.0.3 -> 4.0.4 to fix git.properties generation on java 17

### DIFF
--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <maven.jib.version>2.8.0</maven.jib.version>
         <maven.spring-boot.version>2.6.6</maven.spring-boot.version>
-        <maven.git-commit-id.version>4.0.3</maven.git-commit-id.version>
+        <maven.git-commit-id.version>4.9.10</maven.git-commit-id.version>
 
         <jib.from.image>powsybl/java:2.0.0</jib.from.image>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
bug fix



**What is the current behavior?**
with java17 we get an empty target/classes/git.properties



**What is the new behavior (if this is a feature change)?**
with java17 we get a useful target/classes/git.properties
```
#Generated by Git-Commit-Id-Plugin
git.branch=e29a19dea3e658b8ab20611ca7bc4393480f5d7a
git.build.host=xxxx
git.build.time=2023-07-04T15\:24\:31+0200
git.build.user.email=xxxxxxxx
git.build.user.name=xxxxxx
git.build.version=xxxx
git.closest.tag.commit.count=xxx
git.closest.tag.name=v0.xxxx
git.commit.author.time=2023-06-14T13\:51\:00+0200
git.commit.committer.time=2023-06-14T13\:51\:00+0200
git.commit.id=
git.commit.id.abbrev=
git.commit.id.describe=xxxx
git.commit.id.describe-short=xxxxxx
git.commit.message.full=yyyy
git.commit.message.short=yyyyy
git.commit.time=2023-06-14T13\:51\:00+0200
git.commit.user.email=yyyy
git.commit.user.name=yyyyy
git.dirty=true
git.local.branch.ahead=NO_REMOTE
git.local.branch.behind=NO_REMOTE
git.remote.origin.url=https\://github.com/xxxx
git.tags=v0.xxxx
git.total.commit.count=xxx
```


**Does this PR introduce a breaking change or deprecate an API?**
NO

NOTES:

running a debbugger shows:
java.lang.reflect.InaccessibleObjectException: Unable to make private void java.util.Properties.store0(java.io.BufferedWriter,java.lang.String,boolean) throws java.io.IOException accessible: module java.base does not "opens java.util" to unnamed module @13d289c7

see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/523

