### PR TITLE
Add common lombok config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For normal projects, use powsybl-parent. It provides:
 - a -Prelease profile that activates plugins to upload to ossrh (signing, javadoc, source jar)
 - a -Pjacoco enabling jacoco
 - PluginManagement for various plugins, this means that they are enabled only if you repeat them in the <build><plugins> section of your pom : maven-templating-plugin (filter-src), maven-failsafe-plugin (integration-test, verify), maven-plugin-plugin (process-class, utilisé par itools-packager uniquement..), maven-shade-plugin
+- a base lombok configuration to start with (activable with `-Plombok-config` or `-Dpowsybl.lombok.config=true`)
 
 ### WebService java projects
 Additionally, a powsybl-parent-ws using spring and jib is available. It provides

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For normal projects, use powsybl-parent. It provides:
 - a -Prelease profile that activates plugins to upload to ossrh (signing, javadoc, source jar)
 - a -Pjacoco enabling jacoco
 - PluginManagement for various plugins, this means that they are enabled only if you repeat them in the <build><plugins> section of your pom : maven-templating-plugin (filter-src), maven-failsafe-plugin (integration-test, verify), maven-plugin-plugin (process-class, utilisé par itools-packager uniquement..), maven-shade-plugin
-- a base lombok configuration to start with (activable with a file marker `.mvn/lombok-config-copy.marker` and a forced check with `-Plombok-config-check` or `.mvn/lombok-config-check.marker`)
+- a base lombok configuration to start with (activable with a marker file `.mvn/lombok-config-copy.marker` and a forced check that can be disable with `-P!check-lombok`)
 
 ### WebService java projects
 Additionally, a powsybl-parent-ws using spring and jib is available. It provides

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ For normal projects, use powsybl-parent. It provides:
 - a -Prelease profile that activates plugins to upload to ossrh (signing, javadoc, source jar)
 - a -Pjacoco enabling jacoco
 - PluginManagement for various plugins, this means that they are enabled only if you repeat them in the <build><plugins> section of your pom : maven-templating-plugin (filter-src), maven-failsafe-plugin (integration-test, verify), maven-plugin-plugin (process-class, utilisé par itools-packager uniquement..), maven-shade-plugin
-- a base lombok configuration to start with (activable with a marker file `.mvn/lombok-config-copy.marker` and a forced check that can be disable with `-P!check-lombok`)
+- an optional recommended lombok configuration: to activate it, create an empty file `.mvn/lombok-config-copy.marker`, and make sure that the file `lombok.config` at the root of the project exists and contains the following as the first line:
+  ```
+  import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config
+  ```
+  Note: If you created the marker file, there is a check during the build that the first line of lombok.config is correct. If needed, it can be disabled with `-P'!check-lombok'`.
 
 ### WebService java projects
 Additionally, a powsybl-parent-ws using spring and jib is available. It provides

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For normal projects, use powsybl-parent. It provides:
 - a -Prelease profile that activates plugins to upload to ossrh (signing, javadoc, source jar)
 - a -Pjacoco enabling jacoco
 - PluginManagement for various plugins, this means that they are enabled only if you repeat them in the <build><plugins> section of your pom : maven-templating-plugin (filter-src), maven-failsafe-plugin (integration-test, verify), maven-plugin-plugin (process-class, utilisé par itools-packager uniquement..), maven-shade-plugin
-- a base lombok configuration to start with (activable with `-Plombok-config` or `-Dpowsybl.lombok.config=true`)
+- a base lombok configuration to start with (activable with a file marker `.mvn/lombok-config-copy.marker` and a forced check with `-Plombok-config-check` or `.mvn/lombok-config-check.marker`)
 
 ### WebService java projects
 Additionally, a powsybl-parent-ws using spring and jib is available. It provides

--- a/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
+++ b/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
@@ -1,0 +1,14 @@
+# Don't search another lombok.config file in parent folders
+config.stopbubbling = true
+
+# We add annotations flags for IDEs and tools :
+#  * mark the code as generated for linters and coverage tools
+lombok.addJavaxGeneratedAnnotation = true
+lombok.addLombokGeneratedAnnotation = true
+#  * disable all warnings on generated code for checking tools and IDE (eg. checkstyle)
+lombok.addSuppressWarnings = true
+#  * we prefer the javax Nullable annotation for compatibility with majority of tools
+lombok.addNullAnnotations = javax
+
+# Adding runtime flags for code using reflection on generated beans/dto
+lombok.anyconstructor.addconstructorproperties = true

--- a/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
+++ b/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
@@ -3,10 +3,7 @@ config.stopbubbling = true
 
 # We add annotations flags for IDEs and tools :
 #  * mark the code as generated for linters and coverage tools
-lombok.addJavaxGeneratedAnnotation = true
 lombok.addLombokGeneratedAnnotation = true
-#  * we prefer the javax Nullable annotation for compatibility with majority of tools
-lombok.addNullAnnotations = javax
 
 # Adding runtime flags for code using reflection on generated beans/dto
 lombok.anyconstructor.addconstructorproperties = true

--- a/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
+++ b/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
@@ -4,6 +4,3 @@ config.stopbubbling = true
 # We add annotations flags for IDEs and tools :
 #  * mark the code as generated for linters and coverage tools
 lombok.addLombokGeneratedAnnotation = true
-
-# Adding runtime flags for code using reflection on generated beans/dto
-lombok.anyconstructor.addconstructorproperties = true

--- a/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
+++ b/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
@@ -1,6 +1,5 @@
 # Don't search another lombok.config file in parent folders
 config.stopbubbling = true
 
-# We add annotations flags for IDEs and tools :
-#  * mark the code as generated for linters and coverage tools
+# ignore missing JaCoCo coverage for generated code
 lombok.addLombokGeneratedAnnotation = true

--- a/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
+++ b/powsybl-build-tools/src/main/resources/powsybl-build-tools/lombok.config
@@ -5,8 +5,6 @@ config.stopbubbling = true
 #  * mark the code as generated for linters and coverage tools
 lombok.addJavaxGeneratedAnnotation = true
 lombok.addLombokGeneratedAnnotation = true
-#  * disable all warnings on generated code for checking tools and IDE (eg. checkstyle)
-lombok.addSuppressWarnings = true
 #  * we prefer the javax Nullable annotation for compatibility with majority of tools
 lombok.addNullAnnotations = javax
 

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -370,7 +370,7 @@
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>lombok-copy-deps</id>
+                                <id>lombok-copy-tools</id>
                                 <phase>initialize</phase>
                                 <goals>
                                     <goal>copy</goal>
@@ -416,26 +416,25 @@
                                     <rules>
                                         <requireActiveProfile>
                                             <profiles>lombok-config-copy</profiles>
-                                            <message>The profile "lombok-config-copy" isn't active, please use '-P...' or file marker to activate it.</message>
+                                            <message>The profile "lombok-config-copy" isn't active, please use the marker file to activate it.</message>
                                         </requireActiveProfile>
                                         <requireFilesExist>
                                             <files>
                                                 <file>${project.basedir}/lombok.config</file>
                                             </files>
-                                            <message>Missing file "lombok.config" in project. Please create it or disable check with "-P!check-lombok".</message>
+                                            <message>Missing file "lombok.config" in project. Please create it.</message>
                                         </requireFilesExist>
                                         <requireFilesExist>
                                             <files>
                                                 <file>${project.build.directory}/configs/powsybl-build-tools.jar</file>
                                             </files>
-                                            <message>Error: missing file "target/configs/powsybl-build-tools.jar" (copied by profile lombok-config-copy)...</message>
+                                            <message>Internal error: missing file "target/configs/powsybl-build-tools.jar" (managed by profile lombok-config-copy)...</message>
                                         </requireFilesExist>
                                         <evaluateBeanshell>
                                             <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startsWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>
                                             <message>The lombok.config file must start with the line "import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config"</message>
                                         </evaluateBeanshell>
                                     </rules>
-                                    <fail>true</fail>
                                     <failFast>true</failFast>
                                 </configuration>
                             </execution>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -358,7 +358,6 @@
 
         <profile>
             <id>lombok-config-copy</id>
-            <!-- Add at the start of lombok.config this line: import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config -->
             <activation>
                 <file>
                     <exists>${basedir}/.mvn/lombok-config-copy.marker</exists>
@@ -405,10 +404,10 @@
             </build>
         </profile>
         <profile>
-            <id>lombok-config-check</id>
+            <id>check-lombok</id>
             <activation>
                 <file>
-                    <exists>${basedir}/.mvn/lombok-config-check.marker</exists>
+                    <exists>${basedir}/.mvn/lombok-config-copy.marker</exists><!--active by default and disablable with '-P!...'-->
                 </file>
             </activation>
             <build>
@@ -433,9 +432,16 @@
                                             <files>
                                                 <file>${project.basedir}/lombok.config</file>
                                             </files>
+                                            <message>Missing file "lombok.config" in project. Please create it or disable check with "-P!check-lombok".</message>
+                                        </requireFilesExist>
+                                        <requireFilesExist>
+                                            <files>
+                                                <file>${project.build.directory}/configs/powsybl-build-tools.jar</file>
+                                            </files>
+                                            <message>Error: missing file "target/configs/powsybl-build-tools.jar" (copied by profile lombok-config-copy)...</message>
                                         </requireFilesExist>
                                         <evaluateBeanshell>
-                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>
+                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startsWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>
                                             <message>The lombok.config file must start with the line "import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config"</message>
                                         </evaluateBeanshell>
                                     </rules>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -382,23 +382,13 @@
                                             <artifactId>powsybl-build-tools</artifactId>
                                             <version>${powsybl-build-tools.version}</version>
                                             <type>jar</type>
-                                            <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/configs</outputDirectory>
                                             <destFileName>powsybl-build-tools.jar</destFileName>
                                         </artifactItem>
                                     </artifactItems>
-                                    <outputDirectory>${project.build.directory}/deps</outputDirectory>
-                                    <overWriteReleases>false</overWriteReleases>
-                                    <overWriteSnapshots>true</overWriteSnapshots>
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <showWarnings>true</showWarnings><!--show lombok warning during compile-->
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -407,7 +397,7 @@
             <id>check-lombok</id>
             <activation>
                 <file>
-                    <exists>${basedir}/.mvn/lombok-config-copy.marker</exists><!--active by default and disablable with '-P!...'-->
+                    <exists>${basedir}/.mvn/lombok-config-copy.marker</exists>
                 </file>
             </activation>
             <build>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -50,6 +50,9 @@
         <maven.source.version>3.2.1</maven.source.version>
         <maven.templating.version>1.0.0</maven.templating.version>
 
+        <!-- Some plugins have dependencies we need to add -->
+        <powsybl-build-tools.version>${parent.version}</powsybl-build-tools.version>
+
         <!--
             by default don't override the javadocs. if you want to override the javadocs,
             set the following property in the project
@@ -257,7 +260,7 @@
                           <dependency>
                             <groupId>com.powsybl</groupId>
                             <artifactId>powsybl-build-tools</artifactId>
-                            <version>12-SNAPSHOT</version>
+                            <version>${powsybl-build-tools.version}</version>
                           </dependency>
                         </dependencies>
                     </plugin>
@@ -350,6 +353,73 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>lombok-config</id>
+            <activation>
+                <!--<property>
+                    <name>powsybl.lombok.config</name>
+                    <value>true</value>
+                </property>-->
+                <file>
+                    <exists>lombok.config</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>lombok-copy-deps</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>com.powsybl</groupId>
+                                            <artifactId>powsybl-build-tools</artifactId>
+                                            <version>${powsybl-build-tools.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/configs</outputDirectory>
+                                            <destFileName>powsybl-build-tools.jar</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <outputDirectory>${project.build.directory}/deps</outputDirectory>
+                                    <overWriteReleases>false</overWriteReleases>
+                                    <overWriteSnapshots>true</overWriteSnapshots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>lombok-verify-main-file</id>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <evaluateBeanshell>
+                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").contains("import ./target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>-->
+                                            <!--<condition>java.nio.file.Files.lines(java.nio.file.Paths(".", "lombok.config")).anyMatch(s -> "import ./target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config".equals(s))</condition>-->
+                                        </evaluateBeanshell>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -260,7 +260,7 @@
                           <dependency>
                             <groupId>com.powsybl</groupId>
                             <artifactId>powsybl-build-tools</artifactId>
-                            <version>${powsybl-build-tools.version}</version>
+                            <version>12-SNAPSHOT</version>
                           </dependency>
                         </dependencies>
                     </plugin>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -357,14 +357,15 @@
         </profile>
         <profile>
             <id>lombok-config</id>
+            <!-- Add at the start of lombok.config this line: import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config -->
             <activation>
-                <!--<property>
+                <property>
                     <name>powsybl.lombok.config</name>
                     <value>true</value>
-                </property>-->
-                <file>
+                </property>
+                <!--<file>
                     <exists>lombok.config</exists>
-                </file>
+                </file>-->
             </activation>
             <build>
                 <plugins>
@@ -410,7 +411,7 @@
                                 <configuration>
                                     <rules>
                                         <evaluateBeanshell>
-                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").contains("import ./target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>-->
+                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>
                                             <!--<condition>java.nio.file.Files.lines(java.nio.file.Paths(".", "lombok.config")).anyMatch(s -> "import ./target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config".equals(s))</condition>-->
                                         </evaluateBeanshell>
                                     </rules>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -400,6 +400,9 @@
                     <exists>${basedir}/.mvn/lombok-config-copy.marker</exists>
                 </file>
             </activation>
+            <properties>
+                <powsybl.internal.lombok-import-line>import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config</powsybl.internal.lombok-import-line>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -418,11 +421,11 @@
                                             <files>
                                                 <file>${project.basedir}/lombok.config</file>
                                             </files>
-                                            <message>Missing file "lombok.config" in project. Please create it.</message>
+                                            <message>Missing file "lombok.config" in project. Please create it starting with the following content "${powsybl.internal.lombok-import-line}".</message>
                                         </requireFilesExist>
                                         <evaluateBeanshell>
-                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startsWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>
-                                            <message>The lombok.config file must start with the line "import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config"</message>
+                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("${project.basedir}/lombok.config"), "UTF-8").startsWith("${powsybl.internal.lombok-import-line}")</condition>
+                                            <message>The lombok.config file must start with the line "${powsybl.internal.lombok-import-line}"</message>
                                         </evaluateBeanshell>
                                     </rules>
                                     <failFast>true</failFast>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -51,7 +51,7 @@
         <maven.templating.version>1.0.0</maven.templating.version>
 
         <!-- Some plugins have dependencies we need to add -->
-        <powsybl-build-tools.version>${parent.version}</powsybl-build-tools.version>
+        <powsybl-build-tools.version>${project.parent.version}</powsybl-build-tools.version>
 
         <!--
             by default don't override the javadocs. if you want to override the javadocs,
@@ -355,17 +355,14 @@
                 </pluginManagement>
             </build>
         </profile>
+
         <profile>
-            <id>lombok-config</id>
+            <id>lombok-config-copy</id>
             <!-- Add at the start of lombok.config this line: import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config -->
             <activation>
-                <property>
-                    <name>powsybl.lombok.config</name>
-                    <value>true</value>
-                </property>
-                <!--<file>
-                    <exists>lombok.config</exists>
-                </file>-->
+                <file>
+                    <exists>${basedir}/.mvn/lombok-config-copy.marker</exists>
+                </file>
             </activation>
             <build>
                 <plugins>
@@ -398,6 +395,18 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>lombok-config-check</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/.mvn/lombok-config-check.marker</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
@@ -411,7 +420,8 @@
                                 <configuration>
                                     <rules>
                                         <requireActiveProfile>
-                                            <profiles>lombok-config</profiles>
+                                            <profiles>lombok-config-copy</profiles>
+                                            <message>The profile "lombok-config-copy" isn't active, please use '-P...' or file marker to activate it.</message>
                                         </requireActiveProfile>
                                         <requireFilesExist>
                                             <files>
@@ -420,7 +430,6 @@
                                         </requireFilesExist>
                                         <evaluateBeanshell>
                                             <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>
-                                            <!--<condition>java.nio.file.Files.lines(java.nio.file.Paths(".", "lombok.config")).anyMatch(s -> "import ./target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config".equals(s))</condition>-->
                                             <message>The lombok.config file must start with the line "import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config"</message>
                                         </evaluateBeanshell>
                                     </rules>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -383,7 +383,7 @@
                                             <artifactId>powsybl-build-tools</artifactId>
                                             <version>${powsybl-build-tools.version}</version>
                                             <type>jar</type>
-                                            <overWrite>false</overWrite>
+                                            <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/configs</outputDirectory>
                                             <destFileName>powsybl-build-tools.jar</destFileName>
                                         </artifactItem>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -51,7 +51,12 @@
         <maven.templating.version>1.0.0</maven.templating.version>
 
         <!-- Some plugins have dependencies we need to add -->
-        <powsybl-build-tools.version>${project.parent.version}</powsybl-build-tools.version>
+        <!--
+            Maven don't seem to have a way to reference the version of 'powsybl-parent' from child pom, so we hardcode a value here.
+            For example, in a multi-module project having 'powsybl-parent' as parent and sub-modules having as parent "../pom.xml", ${parent.version} refere to the root project...
+            Remember to update this property when upgrading this artifact, particularly when updating lombok.config in powsybl-build-tools.
+        -->
+        <powsybl-build-tools.version>12-SNAPSHOT</powsybl-build-tools.version>
 
         <!--
             by default don't override the javadocs. if you want to override the javadocs,

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -404,18 +404,28 @@
                         <executions>
                             <execution>
                                 <id>lombok-verify-main-file</id>
-                                <phase>process-sources</phase>
+                                <phase>validate</phase>
                                 <goals>
                                     <goal>enforce</goal>
                                 </goals>
                                 <configuration>
                                     <rules>
+                                        <requireActiveProfile>
+                                            <profiles>lombok-config</profiles>
+                                        </requireActiveProfile>
+                                        <requireFilesExist>
+                                            <files>
+                                                <file>${project.basedir}/lombok.config</file>
+                                            </files>
+                                        </requireFilesExist>
                                         <evaluateBeanshell>
                                             <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>
                                             <!--<condition>java.nio.file.Files.lines(java.nio.file.Paths(".", "lombok.config")).anyMatch(s -> "import ./target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config".equals(s))</condition>-->
+                                            <message>The lombok.config file must start with the line "import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config"</message>
                                         </evaluateBeanshell>
                                     </rules>
                                     <fail>true</fail>
+                                    <failFast>true</failFast>
                                 </configuration>
                             </execution>
                         </executions>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -371,7 +371,7 @@
                         <executions>
                             <execution>
                                 <id>lombok-copy-tools</id>
-                                <phase>initialize</phase>
+                                <phase>validate</phase>
                                 <goals>
                                     <goal>copy</goal>
                                 </goals>
@@ -408,27 +408,17 @@
                         <executions>
                             <execution>
                                 <id>lombok-verify-main-file</id>
-                                <phase>validate</phase>
+                                <phase>initialize</phase>
                                 <goals>
                                     <goal>enforce</goal>
                                 </goals>
                                 <configuration>
                                     <rules>
-                                        <requireActiveProfile>
-                                            <profiles>lombok-config-copy</profiles>
-                                            <message>The profile "lombok-config-copy" isn't active, please use the marker file to activate it.</message>
-                                        </requireActiveProfile>
                                         <requireFilesExist>
                                             <files>
                                                 <file>${project.basedir}/lombok.config</file>
                                             </files>
                                             <message>Missing file "lombok.config" in project. Please create it.</message>
-                                        </requireFilesExist>
-                                        <requireFilesExist>
-                                            <files>
-                                                <file>${project.build.directory}/configs/powsybl-build-tools.jar</file>
-                                            </files>
-                                            <message>Internal error: missing file "target/configs/powsybl-build-tools.jar" (managed by profile lombok-config-copy)...</message>
                                         </requireFilesExist>
                                         <evaluateBeanshell>
                                             <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("lombok.config"), "UTF-8").startsWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config")</condition>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -395,6 +395,12 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <showWarnings>true</showWarnings><!--show lombok warning during compile-->
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] ~Tests for the changes have been added (for bug fixes / features)~
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No.


**What kind of change does this PR introduce?**
Add a profile (inactive by default) to be use by children projects by activating the correct profile.  
It consist of:
  * the common base of lombok configuration in the `/lombok.config` to be reuse by children
  * a check that the configuration is correctly referenced in the project using it


**What is the current behavior?**
Each projects have their own `lombok.config` with duplication and often incomplete.


**What is the new behavior (if this is a feature change)?**
Each children project can have a common base and update can be centralized.


**Does this PR introduce a breaking change or deprecate an API?**
No.


**Other information**:
The idea is to use lombok's [`import`](https://projectlombok.org/features/configuration#import) feature to have a common base for GridSuite projects.

Projects that want to use this project will need to:
  * have this module as parent
  * activate this profile: _(one of the following)_
    - using command line with `-Plombok-config-copy` and `-Plombok-config-check`
    - create the file `.mvn/lombok-config-copy` in the project to activate the copy of the file to be used
    - optionally create the file `.mvn/lombok-config-check` in the project to activate the check that `lombok.config` contains the import
  * add this line _**at the start**_ of `/lombok.config`
      ```properties
      import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config
      ```

This profiles will, when activate:
  1. during `initialize` phase: copy the *powsybl-build-tools* jar in `target/configs/` (to be found and use by lombok)
  2. during `validate` phase: check that the `lombok.config` file have the correct import at the start of the file

This has been tested with Maven, JetBrains IDEA IntelliJ and Eclipse (_with m2e + lombok plugin_).

The `initialize` has been use because of its early position in (Maven lifecycle)[https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html], as IDEs seems to run this phase when reloading/refreshing the project and we need the jar to be present for IDE to parse the configuration (when editing files).


_**Side note**:
No better way found, mainly because of limitation in the way lombok manage internally the import path ([ConfigurationFile](https://github.com/projectlombok/lombok/blob/9e5e0c3803dd5e4306bb54b4976d1c03ec1a8ee2/src/core/lombok/core/configuration/ConfigurationFile.java#L124) and [FileSystemSourceCache](https://github.com/projectlombok/lombok/blob/9e5e0c3803dd5e4306bb54b4976d1c03ec1a8ee2/src/core/lombok/core/configuration/FileSystemSourceCache.java#L62)).
And [that will not change in near future](//github.com/projectlombok/lombok/issues/2158)._