### PR TITLE
Make groovydoc attach artifact (used in releases) less intrusive

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -339,8 +339,12 @@
                             <version>${maven.buildhelper.version}</version>
                             <executions>
                                 <execution>
-                                    <id>attach-artifact</id>
-                                    <phase>package</phase>
+                                    <!--
+                                      phase none here because this is optional (only for groovy projects)
+                                      add this buildhelper execution using this id explicitely and bind to a phase (suggested: package)
+                                    -->
+                                    <id>attach-groovydoc-artifact</id>
+                                    <phase>none</phase>
                                     <goals>
                                         <goal>attach-artifact</goal>
                                     </goals>

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -97,14 +97,6 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!--disable parent pom attaching of groovy-javadoc. Fixes the following error during release:
-                        gpg: impossible d'ouvrir « /tmp/powsybl-parent/powsybl-parent/powsybl-parent-ws/target/powsybl-parent-ws-5-groovydoc.jar » : Aucun fichier ou dossier de ce type
-                        gpg: signing failed: erreur d'ouverture de fichier
-                        -->
-                        <id>attach-artifact</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
                     <goals>
                         <goal>bsh-property</goal>
                     </goals>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
NO


**What kind of change does this PR introduce?**
Cleanup


**What is the current behavior?**
buildhelper maven plugin spurious execution in some projects


**What is the new behavior (if this is a feature change)?**
no spurious execution, more explicit control


**Does this PR introduce a breaking change or deprecate an API?**
YES projects need to adapt their pom

**Other information**:
Previously, any project that used build-helper-maven-plugin for any other objective triggered this execution in the package phase during release. This would then trigger a cascading failure on gpg signing later on:
  gpg: impossible d'ouvrir « /tmp/powsybl-parent/powsybl-parent/powsybl-parent-ws/target/powsybl-parent-ws-5-groovydoc.jar » : Aucun fichier ou dossier de ce type
  gpg: signing failed: erreur d'ouverture de fichier

Projects not using groovy needed to turn it off. Now projects using groovy need to turn it on.

This has the disadvantage of copy pasting the phase everywhere but it shouldn't be a problem (the phase will never change) This has the added advantage that the plugin execution is more explicit now because projects have to add the "attach-groovydoc-artifactId" id, instead of just enabling all build-helper executions diff:
```diff
  <plugin>
      <groupId>org.codehaus.mojo</groupId>
      <artifactId>build-helper-maven-plugin</artifactId>
+     <executions>
+       <execution>
+         <id>attach-groovydoc-artifact</id>
+         <phase>package</phase>
+       </execution>
+     </executions>
  </plugin>

