### PR TITLE
Fix groovy-groovydoc groupId

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -327,7 +327,7 @@
                             </executions>
                             <dependencies>
                                 <dependency>
-                                    <groupId>org.codehaus.groovy</groupId>
+                                    <groupId>org.apache.groovy</groupId>
                                     <artifactId>groovy-groovydoc</artifactId>
                                     <version>${maven.groovydoc.version}</version>
                                 </dependency>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
groovy-groovydoc is with groupId org.codehaus.groovy, which is not correct for the latest versions


**What is the new behavior (if this is a feature change)?**
groovy-groovydoc is with groupId org.apache.groovy



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
No