### PR TITLE
Fix lombok configuration on Windows

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -411,27 +411,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>${maven.buildhelper.version}</version>
-                        <executions>
-                            <execution>
-                                <id>regex-property</id>
-                                <goals>
-                                    <goal>regex-property</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- Change '\' by '/' in ${project.basedir} to allow lombok configuration on Windows -->
-                                    <name>escaped.project.basedir</name>
-                                    <value>${project.basedir}</value>
-                                    <regex>\\</regex>
-                                    <replacement>/</replacement>
-                                    <failIfNoMatch>false</failIfNoMatch>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
                         <executions>
@@ -450,7 +429,7 @@
                                             <message>Missing file "lombok.config" in project. Please create it starting with the following content "${powsybl.internal.lombok-import-line}".</message>
                                         </requireFilesExist>
                                         <evaluateBeanshell>
-                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("${escaped.project.basedir}/lombok.config"), "UTF-8").startsWith("${powsybl.internal.lombok-import-line}")</condition>
+                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File(URI.create("${project.baseUri}").resolve("lombok.config")), "UTF-8").startsWith("${powsybl.internal.lombok-import-line}")</condition>
                                             <message>The lombok.config file must start with the line "${powsybl.internal.lombok-import-line}"</message>
                                         </evaluateBeanshell>
                                     </rules>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -411,6 +411,27 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>${maven.buildhelper.version}</version>
+                        <executions>
+                            <execution>
+                                <id>regex-property</id>
+                                <goals>
+                                    <goal>regex-property</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Change '\' by '/' in ${project.basedir} to allow lombok configuration on Windows -->
+                                    <name>escaped.project.basedir</name>
+                                    <value>${project.basedir}</value>
+                                    <regex>\\</regex>
+                                    <replacement>/</replacement>
+                                    <failIfNoMatch>false</failIfNoMatch>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
                         <executions>
@@ -429,7 +450,7 @@
                                             <message>Missing file "lombok.config" in project. Please create it starting with the following content "${powsybl.internal.lombok-import-line}".</message>
                                         </requireFilesExist>
                                         <evaluateBeanshell>
-                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("${project.basedir}/lombok.config"), "UTF-8").startsWith("${powsybl.internal.lombok-import-line}")</condition>
+                                            <condition>org.codehaus.plexus.util.FileUtils.fileRead(new File("${escaped.project.basedir}/lombok.config"), "UTF-8").startsWith("${powsybl.internal.lombok-import-line}")</condition>
                                             <message>The lombok.config file must start with the line "${powsybl.internal.lombok-import-line}"</message>
                                         </evaluateBeanshell>
                                     </rules>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When a project uses the lombok common configuration introduced by #44, the compilation fails on Windows because of the `\` which are contained in the project path.


**What is the new behavior (if this is a feature change)?**
The compilation must not fail and the common configuration must be taken into account.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
For instance, when compiling `powsybl-networkstore` on Windows, if the project is located in `C:\Path_to\powsybl-network-store`, the error message (before this fix) is:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.4.0:enforce (lombok-verify-main-file) on project powsybl-network-store-model: 
[ERROR] Rule 1: org.apache.maven.enforcer.rules.EvaluateBeanshell failed with message:
[ERROR] Couldn't evaluate condition: org.codehaus.plexus.util.FileUtils.fileRead(new File("C:\Path_to\powsybl-network-store".replace('\\', '/') + "/lombok.config"), "UTF-8").startsWith("import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config"): Sourced file: inline evaluation of: ``org.codehaus.plexus.util.FileUtils.fileRead(new File("C:\Path_to\powsybl-network-st . . . '' Token Parsing Error: Lexical error at line 1, column 58.  Encountered: "P" (87), after : "\"C:\\"

```