### PR TITLE
Update liquibase-hibernate version to 4.26.0

### DIFF
--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -68,8 +68,11 @@
             <column name="myuuid" type="UUID">
             still generates
             <modifyDataType columnName="myuuid" newDataType="bytea"/>
+
+            Switching to liquibase-hibernate.version 4.26.0, which includes resolving the issue where it attempted to connect to the database during changelog generation.
+            This connection issue has been corrected in version 4.26.0, along with potential additional bug fixes and enhancements.
         -->
-        <liquibase-hibernate.version>4.23.2</liquibase-hibernate.version>
+        <liquibase-hibernate.version>4.26.0</liquibase-hibernate.version>
         <validation-api.version>3.0.2</validation-api.version>
         <liquibase-diff.outputFile>src/main/resources/db/changelog/changesets/changelog_${maven.build.timestamp}.xml</liquibase-diff.outputFile>
         <liquibase.username>sa</liquibase.username>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependency update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Use `liquibase-hibernate6` 4.23.2.


**What is the new behavior (if this is a feature change)?**
Use `liquibase-hibernate6` **4.26.0**


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Switching to `liquibase-hibernate` 4.26.0, which includes resolving the issue where it attempted to connect to the database during changelog generation.
This connection issue has been corrected in version 4.26.0, along with potential additional bug fixes and enhancements.
