### PR TITLE
Java 17 -> Java 21 and maven core 3.9.9 and plugin updates 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,25 +91,25 @@
     </developers>
 
     <properties>
-        <maven.core.version>3.8.1</maven.core.version>
+        <maven.core.version>3.9.9</maven.core.version>
 
         <maven.antrun.version>3.1.0</maven.antrun.version>
-        <maven.assembly.version>3.6.0</maven.assembly.version>
-        <maven.buildhelper.version>3.4.0</maven.buildhelper.version>
-        <maven.clean.version>3.3.1</maven.clean.version>
-        <maven.compiler.version>3.11.0</maven.compiler.version>
-        <maven.dependency.version>3.6.0</maven.dependency.version>
-        <maven.deploy.version>3.1.1</maven.deploy.version>
-        <maven.enforcer.version>3.4.0</maven.enforcer.version>
-        <maven.gpg.version>3.1.0</maven.gpg.version>
-        <maven.install.version>3.1.1</maven.install.version>
-        <maven.jar.version>3.3.0</maven.jar.version>
-        <maven.projectinforeports.version>3.4.5</maven.projectinforeports.version>
-        <maven.release.version>3.0.1</maven.release.version>
+        <maven.assembly.version>3.7.1</maven.assembly.version>
+        <maven.buildhelper.version>3.6.0</maven.buildhelper.version>
+        <maven.clean.version>3.4.0</maven.clean.version>
+        <maven.compiler.version>3.13.0</maven.compiler.version>
+        <maven.dependency.version>3.8.1</maven.dependency.version>
+        <maven.deploy.version>3.1.3</maven.deploy.version>
+        <maven.enforcer.version>3.5.0</maven.enforcer.version>
+        <maven.gpg.version>3.2.7</maven.gpg.version>
+        <maven.install.version>3.1.3</maven.install.version>
+        <maven.jar.version>3.4.2</maven.jar.version>
+        <maven.projectinforeports.version>3.8.0</maven.projectinforeports.version>
+        <maven.release.version>3.1.1</maven.release.version>
         <maven.resources.version>3.3.1</maven.resources.version>
-        <maven.site.version>3.12.1</maven.site.version>
-        <maven.surefire.version>3.1.2</maven.surefire.version>
-        <maven.versions.version>2.16.0</maven.versions.version>
+        <maven.site.version>3.21.0</maven.site.version>
+        <maven.surefire.version>3.5.2</maven.surefire.version>
+        <maven.versions.version>2.18.0</maven.versions.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -28,12 +28,12 @@
     </modules>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
-        <maven.buildnumber.version>3.2.0</maven.buildnumber.version>
-        <maven.checkstyle.version>3.3.0</maven.checkstyle.version>
-        <maven.failsafe.version>3.1.2</maven.failsafe.version>
-        <maven.gmavenplus.version>3.0.0</maven.gmavenplus.version>
+        <maven.buildnumber.version>3.2.1</maven.buildnumber.version>
+        <maven.checkstyle.version>3.6.0</maven.checkstyle.version>
+        <maven.failsafe.version>3.5.2</maven.failsafe.version>
+        <maven.gmavenplus.version>4.1.1</maven.gmavenplus.version>
         <!--
             For groovydoc, we must use the same version as the project's groovy version. Standardize on the groovy.version property.
             For projects which don't use groovy at all, this means the pluginmanagement will hold an invalid <version> definition
@@ -43,12 +43,12 @@
             so projects can detect errors early and fix their groovydoc configuration.
         -->
         <maven.groovydoc.version>${groovy.version}</maven.groovydoc.version>
-        <maven.jacoco.version>0.8.10</maven.jacoco.version>
-        <maven.javadoc.version>3.5.0</maven.javadoc.version>
-        <maven.plugin.version>3.9.0</maven.plugin.version>
-        <maven.shade.version>3.5.0</maven.shade.version>
-        <maven.source.version>3.3.0</maven.source.version>
-        <maven.templating.version>1.0.0</maven.templating.version>
+        <maven.jacoco.version>0.8.12</maven.jacoco.version>
+        <maven.javadoc.version>3.11.2</maven.javadoc.version>
+        <maven.plugin.version>3.15.1</maven.plugin.version>
+        <maven.shade.version>3.6.0</maven.shade.version>
+        <maven.source.version>3.3.1</maven.source.version>
+        <maven.templating.version>3.0.0</maven.templating.version>
 
         <!-- Some plugins have dependencies we need to add -->
         <!--
@@ -200,6 +200,75 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>java21+</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <properties>
+                <!--
+                  Temporary solution to remove the JDK21 warning during compilation "Annotation
+                  processing is enabled because one or more processors were
+                  found on the class path." and keep the same behavior as previous JDKs.
+                  This may stop working in the future (java23+ ?) and the
+                  annotation processors probably will have to be explictly
+                  listed using maven's configuration (annotationProcessorPaths ?).
+                  Using this configuration now gives us and the maven community more time to
+                  establish best practices regarding this configuration, how to use it in large
+                  projects with shared inherited build systems.
+                -->
+                <maven.compiler.proc>full</maven.compiler.proc>
+                <!--
+                  need to create an empty argLine property here otherwise tests won't start
+                  with "can't open {argLine}" because of the EnableDynamicAgentLoading workaround
+                -->
+                <argLine/>
+            </properties>
+            <build>
+              <pluginManagement>
+                  <plugins>
+                      <plugin>
+                          <groupId>org.apache.maven.plugins</groupId>
+                          <artifactId>maven-surefire-plugin</artifactId>
+                          <configuration>
+                              <!--
+                                Temporary solution to remove the JDK21 warning during tests using mockito
+                                or other agents "WARNING: A Java agent has been loaded dynamically"
+                                and keep the same behavior as previous JDKs.
+                                This may stop working in the future (java23+ ?) and the
+                                agents probably will have to be explictly
+                                listed using maven's configuration (inject the target artifact jars into argLine).
+                                Using this configuration now gives us and the maven community more time to
+                                establish best practices regarding this configuration, how to use it in large
+                                projects with shared inherited build systems.
+                                @{argLine} syntax to append instead of replace
+                              -->
+                              <argLine>@{argLine} -XX:+EnableDynamicAgentLoading</argLine>
+                          </configuration>
+                      </plugin>
+                      <plugin>
+                          <groupId>org.apache.maven.plugins</groupId>
+                          <artifactId>maven-failsafe-plugin</artifactId>
+                          <configuration>
+                              <!--
+                                  Temporary solution to remove the JDK21 warning during tests using mockito
+                                  or other agents "WARNING: A Java agent has been loaded dynamically"
+                                  and keep the same behavior as previous JDKs.
+                                  This may stop working in the future (java23+ ?) and the
+                                  agents probably will have to be explictly
+                                  listed using maven's configuration (inject the target artifact jars into argLine).
+                                  Using this configuration now gives us and the maven community more time to
+                                  establish best practices regarding this configuration, how to use it in large
+                                  projects with shared inherited build systems.
+                                  @{argLine} syntax to append instead of replace
+                              -->
+                              <argLine>@{argLine} -XX:+EnableDynamicAgentLoading</argLine>
+                          </configuration>
+                      </plugin>
+                  </plugins>
+              </pluginManagement>
             </build>
         </profile>
         <profile>

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -24,11 +24,15 @@
     <description>Powsybl Parent for Web Services</description>
 
     <properties>
-        <maven.jib.version>3.3.2</maven.jib.version>
+        <maven.jib.version>3.4.4</maven.jib.version>
         <maven.spring-boot.version>3.3.3</maven.spring-boot.version>
+        <!--
+          For simplicity, we keep git-commit-id in sync with springboot
+          to behave like spring-boot-starter-parent
+        -->
         <maven.git-commit-id.version>8.0.2</maven.git-commit-id.version>
 
-        <jib.from.image>powsybl/java:2.0.0</jib.from.image>
+        <jib.from.image>powsybl/java:3.0.0</jib.from.image>
 
         <!--
         SPRING_PROFILES_ACTIVE: remove extra profiles. This is used for example to remove the "local" profile


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
upgrade the build system maven and plugins and java version

**What is the current behavior?**
<!-- You can also link to an open issue here -->
java17 required by default
java21 produces warnings


**What is the new behavior (if this is a feature change)?**
require java21 by default and remove jdk21 warnings


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No