### PR TITLE
Add back Maven Deploy Plugin to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <maven.clean.version>3.4.0</maven.clean.version>
         <maven.compiler.version>3.13.0</maven.compiler.version>
         <maven.dependency.version>3.8.1</maven.dependency.version>
+        <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.5.0</maven.enforcer.version>
         <maven.gpg.version>3.2.7</maven.gpg.version>
         <maven.install.version>3.1.3</maven.install.version>
@@ -141,6 +142,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven.dependency.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven.deploy.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Dependency management

**What is the current behavior?**
`maven-deploy-plugin` version was not anymore defined in pluginManagement

**What is the new behavior (if this is a feature change)?**
`maven-deploy-plugin` version is now back in pluginManagement, in case any project needs it, so that it does not defaults to Maven default version (which is very old)

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
