### PR TITLE
liquibase maven plugin version fix

### DIFF
--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <maven.jib.version>3.4.4</maven.jib.version>
-        <maven.spring-boot.version>3.3.3</maven.spring-boot.version>
+        <maven.spring-boot.version>3.4.9</maven.spring-boot.version>
         <!--
           For simplicity, we keep git-commit-id in sync with springboot
           to behave like spring-boot-starter-parent
@@ -54,8 +54,7 @@
         <git-id.failOnUnableToExtractRepoInfo>false</git-id.failOnUnableToExtractRepoInfo>
 
         <!-- for liquibase plugin -->
-        <liquibase-maven-plugin.version>4.29.2</liquibase-maven-plugin.version>
-        <liquibase-hibernate6.version>4.26.0</liquibase-hibernate6.version>
+        <liquibase.version>4.29.2</liquibase.version>
         <validation-api.version>3.0.2</validation-api.version>
         <liquibase-diff.outputFile>src/main/resources/db/changelog/changesets/changelog_${maven.build.timestamp}.xml</liquibase-diff.outputFile>
         <liquibase.username>sa</liquibase.username>
@@ -154,7 +153,7 @@ jib.to.image = finalName;
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase-maven-plugin.version}</version>
+                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>src/main/resources/db/changelog/db.changelog-master.yaml</changeLogFile>
                     <diffChangeLogFile>${liquibase-diff.outputFile}</diffChangeLogFile>
@@ -169,7 +168,7 @@ jib.to.image = finalName;
                     <dependency>
                         <groupId>org.liquibase.ext</groupId>
                         <artifactId>liquibase-hibernate6</artifactId>
-                        <version>${liquibase-hibernate6.version}</version>
+                        <version>${liquibase.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.springframework.boot</groupId>

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -54,29 +54,8 @@
         <git-id.failOnUnableToExtractRepoInfo>false</git-id.failOnUnableToExtractRepoInfo>
 
         <!-- for liquibase plugin -->
-        <liquibase-core.version>4.20.0</liquibase-core.version>
-        <!--
-          liquibase-hibernate6 4.20 (the same as liquibase-core) generates useless changesets, 4.23.2 doesn't seem to have this problem.
-          for example, but maybe there are more
-            existing
-            <column name="mystr" type="VARCHAR(255)">
-            still generates
-            <modifyDataType columnName="mystr" newDataType="varchar(255)"/>
-
-            existing
-            <column name="mydate" type="TIMESTAMP">
-            still generates
-            <modifyDataType columnName="mydate" newDataType="timestamp(6)"/>
-
-            existing
-            <column name="myuuid" type="UUID">
-            still generates
-            <modifyDataType columnName="myuuid" newDataType="bytea"/>
-
-            Switching to liquibase-hibernate.version 4.26.0, which includes resolving the issue where it attempted to connect to the database during changelog generation.
-            This connection issue has been corrected in version 4.26.0, along with potential additional bug fixes and enhancements.
-        -->
-        <liquibase-hibernate.version>4.26.0</liquibase-hibernate.version>
+        <liquibase-maven-plugin.version>4.29.2</liquibase-maven-plugin.version>
+        <liquibase-hibernate6.version>4.26.0</liquibase-hibernate6.version>
         <validation-api.version>3.0.2</validation-api.version>
         <liquibase-diff.outputFile>src/main/resources/db/changelog/changesets/changelog_${maven.build.timestamp}.xml</liquibase-diff.outputFile>
         <liquibase.username>sa</liquibase.username>
@@ -175,7 +154,7 @@ jib.to.image = finalName;
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase-core.version}</version>
+                <version>${liquibase-maven-plugin.version}</version>
                 <configuration>
                     <changeLogFile>src/main/resources/db/changelog/db.changelog-master.yaml</changeLogFile>
                     <diffChangeLogFile>${liquibase-diff.outputFile}</diffChangeLogFile>
@@ -190,7 +169,7 @@ jib.to.image = finalName;
                     <dependency>
                         <groupId>org.liquibase.ext</groupId>
                         <artifactId>liquibase-hibernate6</artifactId>
-                        <version>${liquibase-hibernate.version}</version>
+                        <version>${liquibase-hibernate6.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No.



**What kind of change does this PR introduce?**
Bug fix by updating depencencies update : 
spring-boot-maven-plugin : 3.3.3 => 3.4.9
spring-boot-starter-data-jpa : 3.3.3 => 3.4.9
liquibase-maven-plugin: 4.20.0 => 4.29.2
liquibase-hibernate6 : 4.26.0 => 4.29.2
We want to have this fix (https://github.com/liquibase/liquibase-hibernate/pull/679). The bug causes existing unique constraints to be dropped and recreated on each migration in services like network-modification-server.
And it allows us to have consistent liquibase versions with springboot 3.4.9 (same version for changeset generation and changeset execution)



**What is the current behavior?**
Existing unique constraints are dropped and recreated on each diff/migration.



**What is the new behavior (if this is a feature change)?**
Database migrations generate correct changesets without dropping recreating existing constraints.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
