### PR TITLE
Add "registry" as param when using powsybl.docker.*

### DIFF
--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -109,15 +109,28 @@
                         </properties>
                         <source>
 String useJibDefaultName =
-    session.getUserProperties().getProperty("powsybl.docker.useJibDefaultName",
-    project.getProperties().getProperty("powsybl.docker.useJibDefaultName",
-    "false"));
+    session.getUserProperties().getProperty(
+        "powsybl.docker.useJibDefaultName",
+        project.getProperties().getProperty(
+            "powsybl.docker.useJibDefaultName",
+            "false"
+        )
+    );
 String image =
-    session.getUserProperties().getProperty("image",
-    project.getProperties().getProperty("image"));
+    session.getUserProperties().getProperty(
+        "image",
+        project.getProperties().getProperty("image")
+    );
 String jibtoimage =
-    session.getUserProperties().getProperty("jib.to.image",
-    project.getProperties().getProperty("jib.to.image"));
+    session.getUserProperties().getProperty(
+        "jib.to.image",
+        project.getProperties().getProperty("jib.to.image")
+    );
+String registry =
+    session.getUserProperties().getProperty(
+        "powsybl.docker.registry",
+        project.getProperties().getProperty("powsybl.docker.registry")
+    );
 String finalName;
 if ("false".equals(useJibDefaultName) @and null == image @and null == jibtoimage) {
     String name;
@@ -136,6 +149,14 @@ if ("false".equals(useJibDefaultName) @and null == image @and null == jibtoimage
         "false"));
     if (!"false".equals(keepSnapshotVersion) @or !project.version.endsWith("-SNAPSHOT")) {
         name = name + ":" + project.version;
+    }
+    // Add registry if provided
+    if (registry != null @and registry.trim().length() > 0) {
+        String normalizedRegistry = registry.trim();
+        if (normalizedRegistry.endsWith("/")) {
+            normalizedRegistry = normalizedRegistry.substring(0, normalizedRegistry.length() - 1);
+        }
+        name = normalizedRegistry + "/" + name;
     }
     print("Setting jib.to.image to " + name);
     finalName = name;

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -131,6 +131,15 @@ String registry =
         "powsybl.docker.registry",
         project.getProperties().getProperty("powsybl.docker.registry")
     );
+String imageVersion =
+    session.getUserProperties().getProperty(
+        "powsybl.docker.imageVersion",
+        project.getProperties().getProperty("powsybl.docker.imageVersion")
+    );
+String keepSnapshotVersion =
+    session.getUserProperties().getProperty("powsybl.docker.keepSnapshotVersion",
+    project.getProperties().getProperty("powsybl.docker.keepSnapshotVersion",
+    "false"));
 String finalName;
 if ("false".equals(useJibDefaultName) @and null == image @and null == jibtoimage) {
     String name;
@@ -143,11 +152,9 @@ if ("false".equals(useJibDefaultName) @and null == image @and null == jibtoimage
     } else {
         name = project.artifactId; //the default
     }
-    String keepSnapshotVersion =
-        session.getUserProperties().getProperty("powsybl.docker.keepSnapshotVersion",
-        project.getProperties().getProperty("powsybl.docker.keepSnapshotVersion",
-        "false"));
-    if (!"false".equals(keepSnapshotVersion) @or !project.version.endsWith("-SNAPSHOT")) {
+    if (imageVersion != null @and !imageVersion.trim().isEmpty()) {
+        name = name + ":" + imageVersion.trim();
+    } else if (!"false".equals(keepSnapshotVersion) || !project.version.endsWith("-SNAPSHOT")) {
         name = name + ":" + project.version;
     }
     // Add registry if provided

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -137,9 +137,10 @@ String imageVersion =
         project.getProperties().getProperty("powsybl.docker.imageVersion")
     );
 String keepSnapshotVersion =
-    session.getUserProperties().getProperty("powsybl.docker.keepSnapshotVersion",
-    project.getProperties().getProperty("powsybl.docker.keepSnapshotVersion",
-    "false"));
+    session.getUserProperties().getProperty(
+        "powsybl.docker.keepSnapshotVersion",
+        project.getProperties().getProperty("powsybl.docker.keepSnapshotVersion", "false")
+    );
 String finalName;
 if ("false".equals(useJibDefaultName) @and null == image @and null == jibtoimage) {
     String name;
@@ -154,7 +155,7 @@ if ("false".equals(useJibDefaultName) @and null == image @and null == jibtoimage
     }
     if (imageVersion != null @and !imageVersion.trim().isEmpty()) {
         name = name + ":" + imageVersion.trim();
-    } else if (!"false".equals(keepSnapshotVersion) || !project.version.endsWith("-SNAPSHOT")) {
+    } else if (!"false".equals(keepSnapshotVersion) @or !project.version.endsWith("-SNAPSHOT")) {
         name = name + ":" + project.version;
     }
     // Add registry if provided


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
When building image, if you specify the docker image name (-Dimage / -Djib.to.image), you can specify the registry and the version of the image
If you don't specify any image name, it will generate a name based on the artifact id of the project.

But if you need to build several images with only one maven command, there was no way to specify the targeted registry and the target version for generated images


**What is the new behavior (if this is a feature change)?**
You can now specify a registry, it will then use the generated image name as before, with the registry name added as prefix to the image name, and the version added as a suffix


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No