### PR TITLE
Fix: Update Liquibase version 4.29.2 that does not generate new changes -> 4.31.1 (and springboot 3.4.9 -> 3.5.11 accordingly)

### DIFF
--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -54,7 +54,7 @@
         <git-id.failOnUnableToExtractRepoInfo>false</git-id.failOnUnableToExtractRepoInfo>
 
         <!-- for liquibase plugin -->
-        <liquibase.version>4.29.2</liquibase.version>
+        <liquibase.version>4.31.1</liquibase.version>
         <validation-api.version>3.0.2</validation-api.version>
         <liquibase-diff.outputFile>src/main/resources/db/changelog/changesets/changelog_${maven.build.timestamp}.xml</liquibase-diff.outputFile>
         <liquibase.username>sa</liquibase.username>

--- a/powsybl-parent/powsybl-parent-ws/pom.xml
+++ b/powsybl-parent/powsybl-parent-ws/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <maven.jib.version>3.4.4</maven.jib.version>
-        <maven.spring-boot.version>3.4.9</maven.spring-boot.version>
+        <maven.spring-boot.version>3.5.11</maven.spring-boot.version>
         <!--
           For simplicity, we keep git-commit-id in sync with springboot
           to behave like spring-boot-starter-parent


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Liquibase version <= 4.30 does not generate new changeset correctly: https://github.com/liquibase/liquibase/issues/6148


**What is the new behavior (if this is a feature change)?**
Liquibase version updated to 4.31.1
Upgrade springboot 3.4.9 -> 3.5.11 accordingly. That's what we use and it matches the springboot liquibase version 

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
