### PR TITLE
Remove Windows line restriction from checkstyle rules

### DIFF
--- a/powsybl-build-tools/src/main/resources/powsybl-build-tools/checkstyle.xml
+++ b/powsybl-build-tools/src/main/resources/powsybl-build-tools/checkstyle.xml
@@ -47,11 +47,6 @@
 
     <!-- Regexp -->
     <module name="RegexpMultiline">
-        <property name="id" value="noWindowsLineDelimiter"/>
-        <property name="format" value="(\r\n|\r)"/>
-        <property name="message" value="Line has Windows line delimiter."/>
-    </module>
-    <module name="RegexpMultiline">
         <property name="id" value="noConsecutiveLines"/>
         <property name="format" value="\r?\n[\t ]*\r?\n[\t ]*\r?\n"/>
         <property name="fileExtensions" value="java,xml,properties"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
The checkstyle rule `noWindowsLineDelimiter` forbids to run `mvn clean install` on Windows because git changes the files to adapt the line delimiters to the local OS

**What is the new behavior (if this is a feature change)?**
The rule is removed

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
