### PR TITLE
Add a check on Javadoc and sources JARs artifacts on modules containing classes in their exported JAR

### DIFF
--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -387,6 +387,65 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>check-release-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target xmlns:if="ant:if" xmlns:unless="ant:unless">
+                                        <!-- Skip entirely if no main JAR exists (pom-packaging aggregator modules) -->
+                                        <condition property="jar.exists">
+                                            <available file="${project.build.directory}/${project.build.finalName}.jar"/>
+                                        </condition>
+
+                                        <sequential if:set="jar.exists">
+                                            <!-- Count .class files inside the main JAR -->
+                                            <resourcecount property="class.count">
+                                                <zipfileset src="${project.build.directory}/${project.build.finalName}.jar"
+                                                            includes="**/*.class"/>
+                                            </resourcecount>
+
+                                            <echo message="Found ${class.count} .class file(s) in main JAR"/>
+
+                                            <condition property="has.classes">
+                                                <not><equals arg1="${class.count}" arg2="0"/></not>
+                                            </condition>
+
+                                            <fail message="Module has classes but is missing -sources.jar">
+                                                <condition>
+                                                    <and>
+                                                        <isset property="has.classes"/>
+                                                        <not>
+                                                            <available file="${project.build.directory}/${project.build.finalName}-sources.jar"/>
+                                                        </not>
+                                                    </and>
+                                                </condition>
+                                            </fail>
+
+                                            <fail message="Module has classes but is missing -javadoc.jar">
+                                                <condition>
+                                                    <and>
+                                                        <isset property="has.classes"/>
+                                                        <not>
+                                                            <available file="${project.build.directory}/${project.build.finalName}-javadoc.jar"/>
+                                                        </not>
+                                                    </and>
+                                                </condition>
+                                            </fail>
+
+                                            <echo message="Release artifact check passed."/>
+                                        </sequential>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
                 <pluginManagement>
                     <plugins>

--- a/powsybl-parent/pom.xml
+++ b/powsybl-parent/pom.xml
@@ -411,36 +411,57 @@
                                                             includes="**/*.class"/>
                                             </resourcecount>
 
-                                            <echo message="Found ${class.count} .class file(s) in main JAR"/>
-
                                             <condition property="has.classes">
                                                 <not><equals arg1="${class.count}" arg2="0"/></not>
                                             </condition>
 
-                                            <fail message="Module has classes but is missing -sources.jar">
-                                                <condition>
-                                                    <and>
-                                                        <isset property="has.classes"/>
-                                                        <not>
-                                                            <available file="${project.build.directory}/${project.build.finalName}-sources.jar"/>
-                                                        </not>
-                                                    </and>
-                                                </condition>
-                                            </fail>
+                                            <condition property="missing.sources">
+                                                <and>
+                                                    <isset property="has.classes"/>
+                                                    <not>
+                                                        <available file="${project.build.directory}/${project.build.finalName}-sources.jar"/>
+                                                    </not>
+                                                </and>
+                                            </condition>
 
-                                            <fail message="Module has classes but is missing -javadoc.jar">
-                                                <condition>
-                                                    <and>
-                                                        <isset property="has.classes"/>
-                                                        <not>
-                                                            <available file="${project.build.directory}/${project.build.finalName}-javadoc.jar"/>
-                                                        </not>
-                                                    </and>
-                                                </condition>
-                                            </fail>
+                                            <condition property="missing.javadoc">
+                                                <and>
+                                                    <isset property="has.classes"/>
+                                                    <not>
+                                                        <available file="${project.build.directory}/${project.build.finalName}-javadoc.jar"/>
+                                                    </not>
+                                                </and>
+                                            </condition>
 
-                                            <echo message="Release artifact check passed."/>
+                                            <condition property="check.failed">
+                                                <or>
+                                                    <isset property="missing.sources"/>
+                                                    <isset property="missing.javadoc"/>
+                                                </or>
+                                            </condition>
+
+                                            <sequential if:set="check.failed">
+                                                <echo message=""/>
+                                                <echo message="============================================================"/>
+                                                <echo message=" RELEASE ARTIFACT CHECK FAILED: ${project.artifactId}"/>
+                                                <echo message="============================================================"/>
+                                                <echo message=" Main JAR    : ${project.build.finalName}.jar (${class.count} classes)"/>
+                                                <echo message=" Sources JAR : ${project.build.finalName}-sources.jar  [OK]"      unless:set="missing.sources"/>
+                                                <echo message=" Sources JAR : ${project.build.finalName}-sources.jar  [MISSING]" if:set="missing.sources"/>
+                                                <echo message=" Javadoc JAR : ${project.build.finalName}-javadoc.jar  [OK]"      unless:set="missing.javadoc"/>
+                                                <echo message=" Javadoc JAR : ${project.build.finalName}-javadoc.jar  [MISSING]" if:set="missing.javadoc"/>
+                                                <echo message="============================================================"/>
+                                                <echo message=" Modules with compiled classes must publish -sources.jar"/>
+                                                <echo message=" and -javadoc.jar to Maven Central."/>
+                                                <echo message="============================================================"/>
+                                                <echo message=""/>
+                                                <fail message="Release artifact check failed for ${project.artifactId} — see above for details"/>
+                                            </sequential>
+
+                                            <echo message="${project.artifactId}: release artifact check passed (${class.count} classes)" unless:set="check.failed"/>
                                         </sequential>
+
+                                        <echo message="${project.artifactId}: skipped (no JAR produced)" unless:set="jar.exists"/>
                                     </target>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
Nothing checks that javadoc and source JARs are generated during releases.

**What is the new behavior (if this is a feature change)?**
A new check is done when using the release profile. The build will fail when the module contains classes but either no Javadoc or no source JAR is generated.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
